### PR TITLE
testcases/utility: crashing when "Nonetype" is returned

### DIFF
--- a/testcases/kernelconftest.py
+++ b/testcases/kernelconftest.py
@@ -49,10 +49,10 @@ class kernelconftest(unittest.TestCase):
     Verify if masked CPU cores(indicated in dpdk.conf
     file) are included in isolcpus configuration list
     """
-    @unittest.skipIf(kernel.isolcpus == '', "No isolcpus configuration in gurb")
+    @unittest.skipIf(kernel.isolcpus == '', "No isolcpus configuration in grub")
     def test_maskedcpu_included_ioslcpus(self):
         util.testcase_append_suggestions(self._testMethodName,
-        "Add \'isolcpus\' parameter corresponding to CPU mask to gurb")
+        "Add \'isolcpus\' parameter corresponding to CPU mask to grub")
         masked_cpus = self.sw.get_cpu_list_by_mask(self.cpu.cpu_core_total_num)
         included = True
         for i in masked_cpus:
@@ -68,10 +68,10 @@ class kernelconftest(unittest.TestCase):
     Verify if masked CPU cores(indicated in dpdk.conf
     file) are included in nohz_full configuration list
     """
-    @unittest.skipIf(kernel.nohz_full == '', "No nohz_full configuration in gurb")
+    @unittest.skipIf(kernel.nohz_full == '', "No nohz_full configuration in grub")
     def test_maskedcpu_included_nohz_full(self):
         util.testcase_append_suggestions(self._testMethodName,
-        "Add \'nohz_full\' parameter corresponding to CPU mask to gurb")
+        "Add \'nohz_full\' parameter corresponding to CPU mask to grub")
         masked_cpus = self.sw.get_cpu_list_by_mask(self.cpu.cpu_core_total_num)
         included = True
         for i in masked_cpus:
@@ -87,10 +87,10 @@ class kernelconftest(unittest.TestCase):
     Verify if masked CPU cores(indicated in dpdk.conf
     file) are included in rcu_nocbs configuration list
     """
-    @unittest.skipIf(kernel.rcu_nocbs == '', "No rcu_nocbs configuration in gurb")
+    @unittest.skipIf(kernel.rcu_nocbs == '', "No rcu_nocbs configuration in grub")
     def test_maskedcpu_included_rcu_nocbs(self):
         util.testcase_append_suggestions(self._testMethodName,
-        "Add \'rcu_nocbs\' parameter corresponding to CPU mask to gurb")
+        "Add \'rcu_nocbs\' parameter corresponding to CPU mask to grub")
         masked_cpus = self.sw.get_cpu_list_by_mask(self.cpu.cpu_core_total_num)
         included = True
         for i in masked_cpus:
@@ -106,10 +106,10 @@ class kernelconftest(unittest.TestCase):
     Verify if masked CPU cores(indicated in dpdk.conf
     file) are excluded in kthread configuration list
     """
-    @unittest.skipIf(kernel.kthread_cpus == '', "No kthread_cpus configuration in gurb")
+    @unittest.skipIf(kernel.kthread_cpus == '', "No kthread_cpus configuration in grub")
     def test_maskedcpu_excluded_kthread(self):
         util.testcase_append_suggestions(self._testMethodName,
-        "Add \'kthread_cpus\' parameter corresponding to CPU mask to gurb")
+        "Add \'kthread_cpus\' parameter corresponding to CPU mask to grub")
         masked_cpus = self.sw.get_cpu_list_by_mask(self.cpu.cpu_core_total_num)
         excluded = True
         for i in masked_cpus:
@@ -123,10 +123,10 @@ class kernelconftest(unittest.TestCase):
     Verify if masked CPU cores(indicated in dpdk.conf
     file) are excluded in irqaffinity configuration list
     """
-    @unittest.skipIf(kernel.irqaffinity == '', "No irqaffinity configuration in gurb")
+    @unittest.skipIf(kernel.irqaffinity == '', "No irqaffinity configuration in grub")
     def test_maskedcpu_excluded_irqaffinity(self):
         util.testcase_append_suggestions(self._testMethodName,
-        "Add \'irqaffinity\' parameter corresponding to CPU mask to gurb")
+        "Add \'irqaffinity\' parameter corresponding to CPU mask to grub")
         masked_cpus = self.sw.get_cpu_list_by_mask(self.cpu.cpu_core_total_num)
         excluded = True
         for i in masked_cpus:

--- a/testcases/utility/hardware.py
+++ b/testcases/utility/hardware.py
@@ -225,6 +225,8 @@ class Memory_conf:
 
     def __get_mem_conf_speed(self, index):
         speed = self.__get_mem_dimm_spec_conf("Configured Clock Speed", index)
+        if speed == None:
+            return "Unknown"
         if speed != "Unknown":
             return int(speed.split(" ")[0].strip())
         else:


### PR DESCRIPTION
In hardware.py, the test for memory configured speed
doesn't check if the returned type is of None and still tries to split.
Which will cause the program to crash as you can't split None.

None type is returned if the user doesn't have a Configured Memory Speed
in their dmidecode. Now if None type is returned we send an "Unknown".